### PR TITLE
Fix function pattern bug with type constructors

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,3 +2,11 @@
 {xrl_opts, [{report, true}, {verbose, true}]}.
 {deps, []}.
 {dialyzer, [{warnings, [unknown]}]}.
+
+{plugins, 
+ [{rebar_prv_alpaca, 
+   ".*", 
+   {git, "https://github.com/j14159/rebar_prv_alpaca", {branch, formatter}}}]}.
+
+{provider_hooks, [{post, [{compile, {alpaca, compile}}]},
+                  {pre, [{eunit, {alpaca, compile}}]}]}.

--- a/src/alpaca.erl
+++ b/src/alpaca.erl
@@ -344,4 +344,14 @@ radius_test() ->
     ?assertEqual(1, M1:test_radius(unit)),
     code:delete(M1),
     code:delete(M2).
+
+%% There seems to be a compilation bug in the early formatter work I'm trying
+%% using Alpaca to write its own code formatter.  Figured I might as well just
+%% add the test here.
+own_formatter_test() ->
+    Files = ["src/alpaca_native_ast.alp", "src/alpaca_format.alp"],
+    [M1, M2] = compile_and_load(Files, []),
+    code:delete(M1),
+    code:delete(M2).
+
 -endif.

--- a/src/alpaca_ast_gen.erl
+++ b/src/alpaca_ast_gen.erl
@@ -646,6 +646,14 @@ make_bindings(NV, MN, M, #alpaca_record{members=Members}=R) ->
              is_pattern=true},
     {NV2, M2, NewR};
 
+make_bindings(NV, MN, M, #alpaca_type_apply{arg=none}=TA) ->
+    {NV, M, TA};
+make_bindings(NV, MN, M, #alpaca_type_apply{arg=Arg}=TA) ->
+    case make_bindings(NV, MN, M, Arg) of
+        {NV2, M2, Arg2} -> {NV2, M2, TA#alpaca_type_apply{arg=Arg2}};
+        {error, _}=Err  -> Err
+    end;
+
 make_bindings(NV, _MN, M, {symbol, L, Name}) ->
     case maps:get(Name, M, undefined) of
         undefined ->

--- a/src/alpaca_format.alp
+++ b/src/alpaca_format.alp
@@ -1,0 +1,21 @@
+module alpaca_format
+
+export format/1
+
+import_type alpaca_native_ast.ast
+
+import_type alpaca_native_ast.symbol
+
+format ast_node = format_ast 0 ast_node
+
+max_len = 80
+
+format_ast depth Symbol {name=name} =
+  let end_of_line = depth + (s_len name) in
+  (end_of_line, name)
+       
+--format depth Apply (sym, _) =
+
+s_len s = beam :string :len [s] with
+  l, is_integer l -> l
+  

--- a/src/alpaca_native_ast.alp
+++ b/src/alpaca_native_ast.alp
@@ -1,0 +1,17 @@
+module alpaca_native_ast
+
+export_type ast, symbol, expr
+
+type symbol = Symbol {name: string, line: int}
+
+type expr = Apply (symbol, list expr)
+
+type ast =
+    symbol
+  | expr
+  | Comment {multi_line: bool,
+             line: int,
+             text: string}
+  | Fun {name: symbol,
+         arity: int,
+         versions: list {line: int, args: list ast, body: expr}}

--- a/src/alpaca_typer.erl
+++ b/src/alpaca_typer.erl
@@ -3192,7 +3192,7 @@ module_matching_lists_test() ->
         "a x = match x with "
         "Nil -> :nil"
         "| Cons (i, Nil), is_integer i -> :one_item"
-        "| Cons (i, x) -> :more_than_one",
+        "| Cons (i, xx) -> :more_than_one",
     {ok, _, _, M} = alpaca_ast_gen:parse_module(0, Code),
     Env = new_env(),
     Res = type_module(M, Env),
@@ -3217,11 +3217,11 @@ type_var_protection_test() ->
         "a x = match x with "
         "Nil -> :nil"
         "| Cons (i, Nil), is_integer i -> :one_integer"
-        "| Cons (i, x) -> :more_than_one_integer\n\n"
+        "| Cons (i, xx) -> :more_than_one_integer\n\n"
         "b x = match x with "
         "Nil -> :nil"
         "| Cons (f, Nil), is_float f -> :one_float"
-        "| Cons (f, x) -> :more_than_one_float\n\n"
+        "| Cons (f, xx) -> :more_than_one_float\n\n"
         "c () = (Cons (1.0, Nil), Cons(1, Nil))",
     {ok, _, _, M} = alpaca_ast_gen:parse_module(0, Code),
     Env = new_env(),


### PR DESCRIPTION
We weren't making bindings for the arguments to constructors which was
causing an issue whereby map patterns were being compiled as maps.